### PR TITLE
BERT with 7 nodes 28 tasks --nlayers=96 --emsize=4096 --nhid=16384 --nhead=16

### DIFF
--- a/BERT/bert_cuda_forward_tensor.py
+++ b/BERT/bert_cuda_forward_tensor.py
@@ -174,7 +174,7 @@ def run_worker(rank, world_size, args):
     torch.manual_seed(args.seed)
     os.environ['MASTER_ADDR'] = args.master_addr
     os.environ['MASTER_PORT'] = args.master_port
-    options = rpc.TensorPipeRpcBackendOptions(num_worker_threads=256, rpc_timeout=300)
+    options = rpc.TensorPipeRpcBackendOptions(num_worker_threads=256, rpc_timeout=600)
 
     if rank == 0:
         for i in range(1, world_size):

--- a/BERT/bert_cuda_forward_tensor.sh
+++ b/BERT/bert_cuda_forward_tensor.sh
@@ -5,7 +5,7 @@ export MASTER_ADDR=$(scontrol show hostname ${SLURM_NODELIST} | head -n 1)
 export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
 
 python -u bert_cuda_forward_tensor.py \
-	--nlayers=48 \
+	--nlayers=96 \
 	--emsize=4096 \
 	--nhid=16384 \
 	--nhead=16 \
@@ -13,3 +13,4 @@ python -u bert_cuda_forward_tensor.py \
         --rank=${SLURM_PROCID} \
         --master_addr=${MASTER_ADDR} \
         --master_port=${MASTER_PORT}
+

--- a/BERT/bert_cuda_forward_tensor_interactive.sh
+++ b/BERT/bert_cuda_forward_tensor_interactive.sh
@@ -4,9 +4,9 @@ export USE_TQDM=1
 
 srun --label \
 	--job-name=bert_cuda_forward_tensor_interactive \
-	--ntasks=16 \
+	--ntasks=28 \
 	--partition=q2 \
-	--nodes=4 \
+	--nodes=7 \
 	--gpus-per-node=4 \
 	--gpus-per-task=1 \
 	--time=60:00 \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #15 BERT with 13 nodes 104 tasks --nlayers=96 --emsize=12288 --nhid=49152 --nhead=16
* #14 BERT with 13 nodes 52 tasks --nlayers=96 --emsize=8192 --nhid=32768 --nhead=16
* **#13 BERT with 7 nodes 28 tasks --nlayers=96 --emsize=4096 --nhid=16384 --nhead=16**
* #12 BERT with 16 nodes --nlayers=48 --emsize=4096 --nhid=16384 --nhead=16
* #11 BERT SLURM

