### PR TITLE
BERT with 13 nodes 52 tasks --nlayers=96 --emsize=8192 --nhid=32768 --nhead=16

### DIFF
--- a/BERT/bert_cuda_forward_tensor.sh
+++ b/BERT/bert_cuda_forward_tensor.sh
@@ -6,8 +6,8 @@ export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
 
 python -u bert_cuda_forward_tensor.py \
 	--nlayers=96 \
-	--emsize=4096 \
-	--nhid=16384 \
+	--emsize=8192 \
+	--nhid=32768 \
 	--nhead=16 \
         --world_size=${SLURM_NTASKS} \
         --rank=${SLURM_PROCID} \

--- a/BERT/bert_cuda_forward_tensor_interactive.sh
+++ b/BERT/bert_cuda_forward_tensor_interactive.sh
@@ -4,10 +4,10 @@ export USE_TQDM=1
 
 srun --label \
 	--job-name=bert_cuda_forward_tensor_interactive \
-	--ntasks=28 \
+	--ntasks=52 \
 	--partition=q2 \
-	--nodes=7 \
+	--nodes=13 \
 	--gpus-per-node=4 \
 	--gpus-per-task=1 \
-	--time=60:00 \
+	--time=12:00:00 \
 	bert_cuda_forward_tensor.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #15 BERT with 13 nodes 104 tasks --nlayers=96 --emsize=12288 --nhid=49152 --nhead=16
* **#14 BERT with 13 nodes 52 tasks --nlayers=96 --emsize=8192 --nhid=32768 --nhead=16**
* #13 BERT with 7 nodes 28 tasks --nlayers=96 --emsize=4096 --nhid=16384 --nhead=16
* #12 BERT with 16 nodes --nlayers=48 --emsize=4096 --nhid=16384 --nhead=16
* #11 BERT SLURM

