### PR TITLE
BERT with 13 nodes 104 tasks --nlayers=96 --emsize=12288 --nhid=49152 --nhead=16

### DIFF
--- a/BERT/bert_cuda_forward_tensor.py
+++ b/BERT/bert_cuda_forward_tensor.py
@@ -178,7 +178,7 @@ def run_worker(rank, world_size, args):
     torch.manual_seed(args.seed)
     os.environ['MASTER_ADDR'] = args.master_addr
     os.environ['MASTER_PORT'] = args.master_port
-    options = rpc.TensorPipeRpcBackendOptions(num_worker_threads=256, rpc_timeout=3600)
+    options = rpc.TensorPipeRpcBackendOptions(num_worker_threads=256, rpc_timeout=10800)
 
     if rank == 0:
         for i in range(1, world_size):
@@ -263,7 +263,7 @@ if __name__ == "__main__":
     if args.rank is None:
         mp.spawn(run_worker, args=(args.world_size, args,), nprocs=args.world_size, join=True)
     else:
-        args.world_size -= 1
+        args.world_size -= 5
         if args.rank < args.world_size:
             run_worker(args.rank, args.world_size, args)
 

--- a/BERT/bert_cuda_forward_tensor.sh
+++ b/BERT/bert_cuda_forward_tensor.sh
@@ -6,8 +6,8 @@ export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
 
 python -u bert_cuda_forward_tensor.py \
 	--nlayers=96 \
-	--emsize=8192 \
-	--nhid=32768 \
+	--emsize=12288 \
+	--nhid=49152 \
 	--nhead=16 \
         --world_size=${SLURM_NTASKS} \
         --rank=${SLURM_PROCID} \

--- a/BERT/bert_cuda_forward_tensor_interactive.sh
+++ b/BERT/bert_cuda_forward_tensor_interactive.sh
@@ -4,10 +4,10 @@ export USE_TQDM=1
 
 srun --label \
 	--job-name=bert_cuda_forward_tensor_interactive \
-	--ntasks=52 \
-	--partition=q2 \
+	--ntasks=104 \
+	--partition=q3 \
 	--nodes=13 \
-	--gpus-per-node=4 \
+	--gpus-per-node=8 \
 	--gpus-per-task=1 \
-	--time=12:00:00 \
+	--time=24:00:00 \
 	bert_cuda_forward_tensor.sh

--- a/BERT/bert_cuda_forward_tensor_sbatch.sh
+++ b/BERT/bert_cuda_forward_tensor_sbatch.sh
@@ -2,14 +2,16 @@
 
 #SBATCH --job-name=bert_cuda_forward_tensor_sbatch
 
-#SBATCH --partition=q2
+#SBATCH  --partition=q3
 
-#SBATCH --nodes=4
+#SBATCH --ntasks=104
 
-#SBATCH --gpus-per-node=2
+#SBATCH --nodes=13
+
+#SBATCH --gpus-per-node=8
 
 #SBATCH --gpus-per-task=1
 
-#SBATCH --time=30:00
+#SBATCH --time=24:00:00
 
 srun --label bert_cuda_forward_tensor.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#15 BERT with 13 nodes 104 tasks --nlayers=96 --emsize=12288 --nhid=49152 --nhead=16**
* #14 BERT with 13 nodes 52 tasks --nlayers=96 --emsize=8192 --nhid=32768 --nhead=16
* #13 BERT with 7 nodes 28 tasks --nlayers=96 --emsize=4096 --nhid=16384 --nhead=16
* #12 BERT with 16 nodes --nlayers=48 --emsize=4096 --nhid=16384 --nhead=16
* #11 BERT SLURM

